### PR TITLE
WIP: Add checks for git and re-activate git clone command

### DIFF
--- a/bin/makebuild.sh
+++ b/bin/makebuild.sh
@@ -42,17 +42,30 @@ if [ $? -gt 0 ]; then
 	exit 16
 fi
 
+MIN_GIT_VERSION="2.14.4"
+gitversion="$(git --version)"
+print "$(print "min version $MIN_GIT_VERSION\n$gitversion")" | sort -Vk3 2>/dev/null | tail -1 | grep -q git
+
+if [ $? -gt 0 ]; then
+    echo "Git version >= 2.14.4 is required";
+    exit 16
+fi
+
 MAKEPORT_ROOT="${PWD}"
 
 makebld="${MAKE_VRM}.${MAKE_OS390_TGT_AMODE}.${MAKE_OS390_TGT_LINK}.${MAKE_OS390_TGT_CODEPAGE}"
 MAKEBLD_ROOT="${MAKEPORT_ROOT}/${makebld}";
 
+# if empty, remove directory
+if [ -z "$(ls -A ${MAKEBLD_ROOT})" ]; then
+  rmdir ${MAKEBLD_ROOT}
+fi
+
 if ! [ -d "${MAKEBLD_ROOT}" ]; then
 	mkdir -p "${MAKEBLD_ROOT}"
 	echo "Clone Make"
 	date
-#	(cd "${MAKEBLD_ROOT}" && ${GIT_ROOT}/git clone https://git.savannah.gnu.org/git/make.git)
-	cp -rpf ${MAKE_ROOT}/make.local/${MAKE_VRM}/* "${MAKEBLD_ROOT}"
+	(cd "${MAKEBLD_ROOT}" && git clone https://git.savannah.gnu.org/git/make.git)
 
 	if [ $? -gt 0 ]; then
 		echo "Unable to clone Make directory tree" >&2

--- a/bin/makebuild.sh
+++ b/bin/makebuild.sh
@@ -57,7 +57,7 @@ makebld="${MAKE_VRM}.${MAKE_OS390_TGT_AMODE}.${MAKE_OS390_TGT_LINK}.${MAKE_OS390
 MAKEBLD_ROOT="${MAKEPORT_ROOT}/${makebld}";
 
 # if empty, remove directory
-if [ -z "$(ls -A ${MAKEBLD_ROOT})" ]; then
+if [ -d "${MAKEBLD_ROOT}" && -z "$(ls -A ${MAKEBLD_ROOT})" ]; then
   rmdir ${MAKEBLD_ROOT}
 fi
 
@@ -65,17 +65,9 @@ if ! [ -d "${MAKEBLD_ROOT}" ]; then
 	mkdir -p "${MAKEBLD_ROOT}"
 	echo "Clone Make"
 	date
-	(cd "${MAKEBLD_ROOT}" && git clone https://git.savannah.gnu.org/git/make.git)
-
+	git clone https://git.savannah.gnu.org/git/make.git ${MAKEBLD_ROOT}
 	if [ $? -gt 0 ]; then
 		echo "Unable to clone Make directory tree" >&2
-		exit 16
-	fi
-
-	chtag -R -h -t -cISO8859-1 "${MAKEBLD_ROOT}"
-
-	if [ $? -gt 0 ]; then
-		echo "Unable to tag Make directory tree as ASCII" >&2
 		exit 16
 	fi
 fi

--- a/setenv.sh
+++ b/setenv.sh
@@ -9,10 +9,12 @@ else
 	export _TAG_REDIR_IN="txt"
 	export _TAG_REDIR_OUT="txt"
 
+	export GIT_ROOT=/rsusr/ported/bin
+
 	if [ "$HOME" != '' ] && [ -d $HOME/bin ]; then
-		export PATH=$HOME/bin:/usr/local/bin:/bin:/usr/sbin
+		export PATH=$GIT_ROOT:$HOME/bin:/usr/local/bin:/bin:/usr/sbin:$PATH
 	else
-		export PATH=/usr/local/bin:/bin:/usr/sbin
+		export PATH=$GIT_ROOT:/usr/local/bin:/bin:/usr/sbin:$PATH
 	fi  
 	export LIBPATH=/lib:/usr/lib:/usr/local/lib
 	export LIBOBJDIR=
@@ -24,7 +26,6 @@ else
 	export MAKE_OS390_TGT_CODEPAGE="ascii" # ebcdic|ascii
 
 	export MAKE_ROOT="${PWD}"
-	export GIT_ROOT=/rsusr/ported/bin
 
 	export MAKE_ENV="${MAKE_ROOT}/${MAKE_VRM}.${MAKE_OS390_TGT_AMODE}.${MAKE_OS390_TGT_LINK}.${MAKE_OS390_TGT_CODEPAGE}"
 


### PR DESCRIPTION
* Adds a check for the minimum git version
* If the build dir is empty, it removes it.  This can happen if the clone fails and you re-run makebuild.sh
* It also adds GIT_ROOT to the PATH envar and assumes git is in the PATH envar going forward.  This also allows for configurations to have git in another path.  